### PR TITLE
連続会話機能を追加

### DIFF
--- a/index.js
+++ b/index.js
@@ -2273,7 +2273,7 @@ client.on('messageCreate', async msg => {
                     content:e.content.replace(chatGPT, "")
                 }
             }).reverse();
-            while(messages.length!==1 && messages.reduce((sum,e)=>e.content.length+sum,0)>=100){
+            while(messages.length!==1 && messages.reduce((sum,e)=>e.content.length+sum,0)>=200){
                 messages = messages.slice(1);
             }
             console.log(messages);

--- a/index.js
+++ b/index.js
@@ -2247,21 +2247,49 @@ client.on('messageCreate', async msg => {
             })
     }
 
-    if (msg.content.startsWith(chatGPT)){
+    
+    let messages = [];
+    if(!msg.author.bot){
+        let msg_p = msg;
+        let chan = await client.channels.fetch(msg.channelId);
+        messages.push(msg_p);
+        while(msg_p.reference){
+            msg_p = await chan.messages.fetch(msg_p.reference.messageId);
+            if(msg_p && !msg_p.author.bot) messages.push(msg_p);
+        }
+    }
+    let last_message = messages[messages.length-1];
+
+    if (msg.content.startsWith(chatGPT) || last_message.content?.startsWith(chatGPT)){
         const configuration = new Configuration({
             apiKey: process.env.OPENAI_API_KEY,
         });
         try{
+            console.log(msg.content);
+            // console.log(messages);
+            messages = messages.map(e => {
+                return {
+                    role:'user', 
+                    content:e.content.replace(chatGPT, "")
+                }
+            }).reverse();
+            while(messages.length!==1 && messages.reduce((sum,e)=>e.content.length+sum,0)>=100){
+                messages = messages.slice(1);
+            }
+            console.log(messages);
+            console.log("==================");
             const openai = new OpenAIApi(configuration);
             const ask = msg.content.slice(chatGPT.length);
+            const message = {role: "user", content: ask};
             const res = await openai.createChatCompletion({
                 model: "gpt-3.5-turbo-0301",
-                messages: [{ role: "user", content: ask }],
+                messages: messages,
             });
             const answer = res.data.choices[0].message?.content;
             await msg.reply(answer);
         }catch(e){
-            msg.reply("AIも休みほしい時があんねん"); 
+            msg.reply("なんやて？もっかい頼むわ"); 
+            console.log(e);
         }
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,51 +19,63 @@
       }
     },
     "node_modules/@discordjs/builders": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.4.0.tgz",
-      "integrity": "sha512-nEeTCheTTDw5kO93faM1j8ZJPonAX86qpq/QVoznnSa8WWcCgJpjlu6GylfINTDW6o7zZY0my2SYdxx2mfNwGA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.5.0.tgz",
+      "integrity": "sha512-7XxT78mnNBPigHn2y6KAXkicxIBFtZREGWaRZ249EC1l6gBUEP8IyVY5JTciIjJArxkF+tg675aZvsTNTKBpmA==",
       "dependencies": {
-        "@discordjs/util": "^0.1.0",
-        "@sapphire/shapeshift": "^3.7.1",
-        "discord-api-types": "^0.37.20",
+        "@discordjs/formatters": "^0.2.0",
+        "@discordjs/util": "^0.2.0",
+        "@sapphire/shapeshift": "^3.8.1",
+        "discord-api-types": "^0.37.35",
         "fast-deep-equal": "^3.1.3",
-        "ts-mixer": "^6.0.2",
-        "tslib": "^2.4.1"
+        "ts-mixer": "^6.0.3",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=16.9.0"
       }
     },
     "node_modules/@discordjs/collection": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.3.0.tgz",
-      "integrity": "sha512-ylt2NyZ77bJbRij4h9u/wVy7qYw/aDqQLWnadjvDqW/WoWCxrsX6M3CIw9GVP5xcGCDxsrKj5e0r5evuFYwrKg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.4.0.tgz",
+      "integrity": "sha512-hiOJyk2CPFf1+FL3a4VKCuu1f448LlROVuu8nLz1+jCOAPokUcdFAV+l4pd3B3h6uJlJQSASoZzrdyNdjdtfzQ==",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/@discordjs/formatters": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.2.0.tgz",
+      "integrity": "sha512-vn4oMSXuMZUm8ITqVOtvE7/fMMISj4cI5oLsR09PEQXHKeKDAMLltG/DWeeIs7Idfy6V8Fk3rn1e69h7NfzuNA==",
+      "dependencies": {
+        "discord-api-types": "^0.37.35"
+      },
       "engines": {
         "node": ">=16.9.0"
       }
     },
     "node_modules/@discordjs/rest": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-1.5.0.tgz",
-      "integrity": "sha512-lXgNFqHnbmzp5u81W0+frdXN6Etf4EUi8FAPcWpSykKd8hmlWh1xy6BmE0bsJypU1pxohaA8lQCgp70NUI3uzA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-1.6.0.tgz",
+      "integrity": "sha512-HGvqNCZ5Z5j0tQHjmT1lFvE5ETO4hvomJ1r0cbnpC1zM23XhCpZ9wgTCiEmaxKz05cyf2CI9p39+9LL+6Yz1bA==",
       "dependencies": {
-        "@discordjs/collection": "^1.3.0",
-        "@discordjs/util": "^0.1.0",
+        "@discordjs/collection": "^1.4.0",
+        "@discordjs/util": "^0.2.0",
         "@sapphire/async-queue": "^1.5.0",
-        "@sapphire/snowflake": "^3.2.2",
-        "discord-api-types": "^0.37.23",
-        "file-type": "^18.0.0",
-        "tslib": "^2.4.1",
-        "undici": "^5.13.0"
+        "@sapphire/snowflake": "^3.4.0",
+        "discord-api-types": "^0.37.35",
+        "file-type": "^18.2.1",
+        "tslib": "^2.5.0",
+        "undici": "^5.20.0"
       },
       "engines": {
         "node": ">=16.9.0"
       }
     },
     "node_modules/@discordjs/util": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-0.1.0.tgz",
-      "integrity": "sha512-e7d+PaTLVQav6rOc2tojh2y6FE8S7REkqLldq1XF4soCx74XB/DIjbVbVLtBemf0nLW77ntz0v+o5DytKwFNLQ==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-0.2.0.tgz",
+      "integrity": "sha512-/8qNbebFzLWKOOg+UV+RB8itp4SmU5jw0tBUD3ifElW6rYNOj1Ku5JaSW7lLl/WgjjxF01l/1uQPCzkwr110vg==",
       "engines": {
         "node": ">=16.9.0"
       }
@@ -105,9 +117,9 @@
       "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
     },
     "node_modules/@types/node": {
-      "version": "18.14.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.6.tgz",
-      "integrity": "sha512-93+VvleD3mXwlLI/xASjw0FzKcwzl3OdTCzm1LaRfqgS21gfFtK3zDXM5Op9TeeMsJVOaJ2VRDpT9q4Y3d0AvA=="
+      "version": "18.15.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.3.tgz",
+      "integrity": "sha512-p6ua9zBxz5otCmbpb5D3U4B5Nanw6Pk3PPyX05xnxbB/fRv71N7CPmORg7uAD5P70T0xmx1pzAx/FUfa5X+3cw=="
     },
     "node_modules/@types/ws": {
       "version": "8.5.4",
@@ -217,6 +229,19 @@
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/boolbase": {
@@ -470,27 +495,28 @@
       }
     },
     "node_modules/discord-api-types": {
-      "version": "0.37.35",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.35.tgz",
-      "integrity": "sha512-iyKZ/82k7FX3lcmHiAvvWu5TmyfVo78RtghBV/YsehK6CID83k5SI03DKKopBcln+TiEIYw5MGgq7SJXSpNzMg=="
+      "version": "0.37.36",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.36.tgz",
+      "integrity": "sha512-Nlxmp10UpVr/utgZ9uODQvG2Or+5w7LFrvFMswyeKC9l/+UaqGT6H0OVgEFhu9GEO4U6K7NNO5W8Carv7irnCA=="
     },
     "node_modules/discord.js": {
-      "version": "14.7.1",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.7.1.tgz",
-      "integrity": "sha512-1FECvqJJjjeYcjSm0IGMnPxLqja/pmG1B0W2l3lUY2Gi4KXiyTeQmU1IxWcbXHn2k+ytP587mMWqva2IA87EbA==",
+      "version": "14.8.0",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.8.0.tgz",
+      "integrity": "sha512-UOxYtc/YnV7jAJ2gISluJyYeBw4e+j8gWn+IoqG8unaHAVuvZ13DdYN0M1f9fbUgUvSarV798inIrYFtDNDjwQ==",
       "dependencies": {
-        "@discordjs/builders": "^1.4.0",
-        "@discordjs/collection": "^1.3.0",
-        "@discordjs/rest": "^1.4.0",
-        "@discordjs/util": "^0.1.0",
-        "@sapphire/snowflake": "^3.2.2",
-        "@types/ws": "^8.5.3",
-        "discord-api-types": "^0.37.20",
+        "@discordjs/builders": "^1.5.0",
+        "@discordjs/collection": "^1.4.0",
+        "@discordjs/formatters": "^0.2.0",
+        "@discordjs/rest": "^1.6.0",
+        "@discordjs/util": "^0.2.0",
+        "@sapphire/snowflake": "^3.4.0",
+        "@types/ws": "^8.5.4",
+        "discord-api-types": "^0.37.35",
         "fast-deep-equal": "^3.1.3",
         "lodash.snakecase": "^4.1.1",
-        "tslib": "^2.4.1",
-        "undici": "^5.13.0",
-        "ws": "^8.11.0"
+        "tslib": "^2.5.0",
+        "undici": "^5.20.0",
+        "ws": "^8.12.1"
       },
       "engines": {
         "node": ">=16.9.0"
@@ -674,16 +700,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
       "dependencies": {
         "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
+        "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
       },
       "engines": {
-        "node": ">= 0.12"
+        "node": ">= 6"
       }
     },
     "node_modules/fs-constants": {
@@ -986,14 +1012,11 @@
       "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
     },
     "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/mime-db": {
@@ -1058,41 +1081,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/mysql/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/mysql/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
-    "node_modules/mysql/node_modules/sqlstring": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.1.tgz",
-      "integrity": "sha512-ooAzh/7dxIG5+uDik1z/Rd1vli0+38izZhGzSa34FwR7IbelPWCCKSNIl8jlL/F7ERvy8CB2jNeM1E9i9mXMAQ==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mysql/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "node_modules/mysql2": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.2.0.tgz",
@@ -1111,12 +1099,12 @@
         "node": ">= 8.0"
       }
     },
-    "node_modules/mysql2/node_modules/lru-cache": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+    "node_modules/mysql2/node_modules/sqlstring": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
+      "integrity": "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==",
       "engines": {
-        "node": ">=12"
+        "node": ">= 0.6"
       }
     },
     "node_modules/named-placeholders": {
@@ -1128,14 +1116,6 @@
       },
       "engines": {
         "node": ">=12.0.0"
-      }
-    },
-    "node_modules/named-placeholders/node_modules/lru-cache": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/napi-build-utils": {
@@ -1193,19 +1173,6 @@
       "dependencies": {
         "axios": "^0.26.0",
         "form-data": "^4.0.0"
-      }
-    },
-    "node_modules/openai/node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/parse5": {
@@ -1333,16 +1300,17 @@
       }
     },
     "node_modules/readable-stream": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.1.tgz",
-      "integrity": "sha512-+rQmrWMYGA90yenhTYsLWAsLsqVC8osOw6PKE1HDYiO0gdPeKe/xDHNzIAIn4C91YQ6oenEhfYqqc1883qHbjQ==",
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
       "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "node_modules/readable-web-to-node-stream": {
@@ -1358,6 +1326,19 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/readable-web-to-node-stream/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/rechoir": {
@@ -1402,6 +1383,19 @@
         "node": ">= 6"
       }
     },
+    "node_modules/request/node_modules/form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
@@ -1427,23 +1421,9 @@
       }
     },
     "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -1464,6 +1444,17 @@
       },
       "bin": {
         "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
       },
       "engines": {
         "node": ">=10"
@@ -1548,9 +1539,9 @@
       }
     },
     "node_modules/sqlstring": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
-      "integrity": "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.1.tgz",
+      "integrity": "sha512-ooAzh/7dxIG5+uDik1z/Rd1vli0+38izZhGzSa34FwR7IbelPWCCKSNIl8jlL/F7ERvy8CB2jNeM1E9i9mXMAQ==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -1588,11 +1579,11 @@
       }
     },
     "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dependencies": {
-        "safe-buffer": "~5.2.0"
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/strip-json-comments": {
@@ -1654,6 +1645,19 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tar-stream/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/tarn": {
@@ -1727,9 +1731,9 @@
       "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
     },
     "node_modules/undici": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
-      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.21.0.tgz",
+      "integrity": "sha512-HOjK8l6a57b2ZGXOcUsI5NLfoTrfmbOl90ixJDl0AEFG4wgHNDQxtZy15/ZQp7HhjkpaGlp/eneMgtsu1dIlUA==",
       "dependencies": {
         "busboy": "^1.6.0"
       },
@@ -1783,9 +1787,9 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/ws": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.12.1.tgz",
-      "integrity": "sha512-1qo+M9Ba+xNhPB+YTWUlK6M17brTut5EXbcBaMRN5pH5dFrXz7lzz1ChFSUq3bOUl8yEvSenhHmYUNJxFzdJew==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
       "engines": {
         "node": ">=10.0.0"
       },


### PR DESCRIPTION
## 概要
今までは単発でしか出来なかったchatGPTの対話機能を、連続で行えるようにした。

## 詳細
- トークンを節約するため、APIに送るのはこれまでの自分の発言のみ
- 過去のchatGPT自身の発言は勘案していないので、実はなんちゃって対話である（それでもなんとかなる）
- しりとりとかは出来ないはず
- また、文字の長さが200を超えたら、過去の会話から外していくようにする。