### PR TITLE
chatGPTによる対話機能を追加

### DIFF
--- a/src/library/DiscordUtil.js
+++ b/src/library/DiscordUtil.js
@@ -28,8 +28,8 @@ class DiscordUtil {
 
     /**
      * メッセージに平文をリプライする。
-     * @param {Message} msg 
-     * @param {string} text 
+     * @param {Message} msg 返信するDiscordメッセージオブジェクト
+     * @param {string} text 返信するテキスト
      * @returns {Message}
      */
     static async replyText(msg, text){
@@ -210,6 +210,24 @@ class DiscordUtil {
         messageObj.embeds = [embed];
         
         return messageObj;
+    }
+
+    /**
+     * エラーメッセージをリプライする
+     * @param {Message} msg 
+     * @param {string} errorMessage 
+     */
+    static replyErrorMessage(msg, errorMessage = 'エラーやわ'){
+        msg.reply(errorMessage);
+    }
+
+    /**
+     * メッセージの送信者が管理者かどうか判定する
+     * @param {User} author 
+     * @returns {boolean}
+     */
+    static isAdministrator(author){
+        return author.id === process?.env['ADMINISTRATOR_DISCORD_ID'];
     }
 }
 

--- a/src/library/Util.js
+++ b/src/library/Util.js
@@ -32,13 +32,19 @@ class Util{
     }
 
     /**
-     * ログを出力する
-     * 2023年1月1日0時0分0秒 [DICE] 1d100 <= 20 
-     * @param {string} classification 
-     * @param {string} text 
+     * 日付を付けてログを出力する
+     * 2023年1月1日0時0分0秒...
+     * @param {*} arguments 可変パラメータ
      */
-    static log(text){
-        console.log(`${this.getTime()[0]} ${text.includes('\n') ? '\n'+text : text}`);
+    static log(){
+        let args = [];
+        if(arguments.length >= 1){
+            Object.keys(arguments).forEach(key=>{
+                args.push(arguments[key]);
+            });
+            args[0] = args[0].includes('\n') ? '\n'+args[0] : args[0];    
+        }
+        console.log(this.getTime()[0], ...args);
     }
 
     /**

--- a/src/library/chatGPT.js
+++ b/src/library/chatGPT.js
@@ -1,0 +1,39 @@
+const { Util } = require('./Util');
+const { Configuration, OpenAIApi } = require('openai');
+
+class ChatGPT {
+
+    constructor(){
+        this.configuration = new Configuration({
+            apiKey: process.env.OPENAI_API_KEY,
+        });
+        this.openai = new OpenAIApi(this.configuration);
+    }
+
+    /**
+     * chatGPTのAPIを叩いて、返答を返す
+     * @param {Array} messages [{role:'assistant'|'user', content: "how are you?"}]
+     * @returns {string} 返答
+     */
+    async getAnswer(messages){
+        try{
+            // openaiのAPIを叩いて返答を取得
+            const res = await this.openai.createChatCompletion({
+                model: "gpt-3.5-turbo-0301",
+                messages: messages,
+            });
+            let answer = res.data.choices[0].message?.content;
+            Util.log(`[chatGPT] total token:${res.data.usage.total_tokens}. Answer:${answer.slice(0,10)+'...'}`);
+
+            // 本文を返す
+            return answer;
+
+        }catch(e){
+            Util.error(e);
+            return '';
+        }
+    }
+
+}
+
+module.exports = { ChatGPT };


### PR DESCRIPTION
## 概要
- chatGPTによる対話機能を追加した
- ```Util.log()```を可変数個の引数に対応した


## 詳細
```!c, 【対話】``` でopenAIのAPIを叩いて、返答をリプライする。
さいころ君のリプライに対して更に返信すると、対話を継続することができる。
新しくコマンドを使った場合、これまでの対話は引き継がれない。
また、管理者以外は、対話の総文字数が1000文字を超えると古い会話から削除する制限を付けた（トークン節約用）

## 画像
![image](https://user-images.githubusercontent.com/48784423/227232423-52672514-105b-4025-a1b2-ed0824247180.png)


## その他
モデルはGPT3.5です。
4.0は、API利用料金が安くなったら対応するかも...
というか今のトークンもフリートライアルのやつだし笑