### PR TITLE
天気予報機能の追加

### DIFF
--- a/src/DiscordClient.js
+++ b/src/DiscordClient.js
@@ -54,27 +54,6 @@ class DiscordClient{
      * @returns 
      */
     async parseMessage(msg){
-        if(msg.content.startsWith('!test')){
-            const empty = Util.emoji['space'];
-            const sunny = Util.emoji['sunny'];
-            const left = Util.emoji['arrow_left'];
-            const right = Util.emoji['arrow_right'];
-            const red = DiscordUtil.makeStyleKeyword({color:'red'});
-            const blue = DiscordUtil.makeStyleKeyword({color:'blue'}); 
-            let embed = new EmbedBuilder()
-            .setTitle('京都')
-            .setDescription(`3/1(日)の天気`)
-            .addFields({ name: '21時　'+sunny+'　　'+empty, value: "```ansi\n" + `\n${red}15℃\n${blue}0%` + "\n```", inline: true })
-            .addFields({ name: '21時　'+sunny+'　　'+empty, value: "```ansi\n" + `\n${red}15℃\n${blue}0%` + "\n```", inline: true })
-            .addFields({ name: '21時　'+sunny+'　　'+empty, value: "```ansi\n" + `\n${red}15℃\n${blue}0%` + "\n```", inline: true })
-            .addFields({ name: '21時　'+sunny+'　　'+empty, value: "```ansi\n" + `\n${red}15℃\n${blue}0%` + "\n```", inline: true })
-            .addFields({ name: '21時　'+sunny+'　　'+empty, value: "```ansi\n" + `\n${red}15℃\n${blue}0%` + "\n```", inline: true })
-            .addFields({ name: '21時　'+sunny+'　　'+empty, value: "```ansi\n" + `\n${red}15℃\n${blue}0%` + "\n```", inline: true })
-            .setFooter({text: `${left}2/28(土)　　　　　　　　　　　　3/2(月)${right}`});
-            let rep = await DiscordUtil.replyEmbed(msg, embed);
-            await rep.react(left);
-            await rep.react(right);
-        }
 
         // botのメッセージは処理しない
         if(msg.author.bot) return;

--- a/src/DiscordClient.js
+++ b/src/DiscordClient.js
@@ -1,4 +1,4 @@
-const { Client, Events, User } = require('discord.js');
+const { Client, Events, User, EmbedBuilder } = require('discord.js');
 const { Util } = require('./library/Util');
 const { DiscordUtil } = require('./library/DiscordUtil');
 const { commands, getCommand, getBodyText } = require('./library/command');
@@ -6,6 +6,7 @@ const { Random } = require('./library/Random');
 const { Divination } = require('./library/Divination');
 const { ChatGPT } = require('./library/ChatGPT');
 const { Lottery } = require('./library/discord/Lottery');
+const { DiscordWeatherForecast } = require('./library/discord/DiscordWeatherForecast');
 
 /**
  * discordのclientクラス
@@ -38,9 +39,6 @@ class DiscordClient{
             if(this.acceptable) this.parseMessage(msg);
         });
 
-        // リアクション付与検出時の処理
-
-
         // クライアントログイン完了時の処理
         this.client.on(Events.ClientReady, () => {
             Util.log(`${this.client.user.tag} でログインしています。`);
@@ -56,6 +54,28 @@ class DiscordClient{
      * @returns 
      */
     async parseMessage(msg){
+        if(msg.content.startsWith('!test')){
+            const empty = Util.emoji['space'];
+            const sunny = Util.emoji['sunny'];
+            const left = Util.emoji['arrow_left'];
+            const right = Util.emoji['arrow_right'];
+            const red = DiscordUtil.makeStyleKeyword({color:'red'});
+            const blue = DiscordUtil.makeStyleKeyword({color:'blue'}); 
+            let embed = new EmbedBuilder()
+            .setTitle('京都')
+            .setDescription(`3/1(日)の天気`)
+            .addFields({ name: '21時　'+sunny+'　　'+empty, value: "```ansi\n" + `\n${red}15℃\n${blue}0%` + "\n```", inline: true })
+            .addFields({ name: '21時　'+sunny+'　　'+empty, value: "```ansi\n" + `\n${red}15℃\n${blue}0%` + "\n```", inline: true })
+            .addFields({ name: '21時　'+sunny+'　　'+empty, value: "```ansi\n" + `\n${red}15℃\n${blue}0%` + "\n```", inline: true })
+            .addFields({ name: '21時　'+sunny+'　　'+empty, value: "```ansi\n" + `\n${red}15℃\n${blue}0%` + "\n```", inline: true })
+            .addFields({ name: '21時　'+sunny+'　　'+empty, value: "```ansi\n" + `\n${red}15℃\n${blue}0%` + "\n```", inline: true })
+            .addFields({ name: '21時　'+sunny+'　　'+empty, value: "```ansi\n" + `\n${red}15℃\n${blue}0%` + "\n```", inline: true })
+            .setFooter({text: `${left}2/28(土)　　　　　　　　　　　　3/2(月)${right}`});
+            let rep = await DiscordUtil.replyEmbed(msg, embed);
+            await rep.react(left);
+            await rep.react(right);
+        }
+
         // botのメッセージは処理しない
         if(msg.author.bot) return;
 
@@ -149,6 +169,7 @@ class DiscordClient{
                 DiscordUtil.replyComplexText(msg, textArr);
                 break;
             case "keyWeather" :
+                DiscordWeatherForecast.showWeatherForecast(msg, bodyText);
                 break;
             case "keyLuna" :
                 break;

--- a/src/library/DiscordUtil.js
+++ b/src/library/DiscordUtil.js
@@ -61,7 +61,7 @@ class DiscordUtil {
             let text = '';
 
             textArray.forEach(it => {
-                text += DiscordUtil._makeStyleKeyword(it.style) + it.text;
+                text += DiscordUtil.makeStyleKeyword(it.style) + it.text;
             });
 
             let replyText = '```ansi\n' + text + '\n```';
@@ -108,7 +108,7 @@ class DiscordUtil {
                 else{
                     let codeBlock = '';
                     it.codeArray.forEach(code => {
-                        codeBlock += DiscordUtil._makeStyleKeyword(code.style) + code.text;
+                        codeBlock += DiscordUtil.makeStyleKeyword(code.style) + code.text;
                     });
                     text += '```ansi\n' + codeBlock + '\n```';                    
                 }
@@ -122,7 +122,7 @@ class DiscordUtil {
         
     }
 
-    static _makeStyleKeyword(style){
+    static makeStyleKeyword(style){
         if(!style) return '';
         let keyword =[];
         

--- a/src/library/DiscordUtil.js
+++ b/src/library/DiscordUtil.js
@@ -179,7 +179,7 @@ class DiscordUtil {
         // Util.log(`[EMBED]:${embed.data.title}`);
         messageObj.files = [];
 
-        if(!embed.color) embed.setColor(0x0099FF);
+        if(!embed.data?.color && !embed?.color) embed.setColor(0x0099FF);
         // 添付画像
         if(imageUrls?.image){
             let ext = imageUrls.image.split('.').pop();
@@ -199,13 +199,15 @@ class DiscordUtil {
             messageObj.files.push(thumbnail);
         }
         // さいころ君の画像
-        let authorIconUrl = './images/saikoro.png';
-        let ext = authorIconUrl.split('.').pop();
-        const authorIcon = new AttachmentBuilder()
-            .setName('authorIconFile.' + ext)
-            .setFile(authorIconUrl);
-        embed.setAuthor({ name: 'さいころ君', iconURL: 'attachment://authorIconFile.' + ext});
-        messageObj.files.push(authorIcon);
+        if(!embed.data?.author && !embed?.author){
+            let authorIconUrl = './images/saikoro.png';
+            let ext = authorIconUrl.split('.').pop();
+            const authorIcon = new AttachmentBuilder()
+                .setName('authorIconFile.' + ext)
+                .setFile(authorIconUrl);
+            embed.setAuthor({ name: 'さいころ君', iconURL: 'attachment://authorIconFile.' + ext});
+            messageObj.files.push(authorIcon);
+        }
 
         messageObj.embeds = [embed];
         

--- a/src/library/GeoCoding.js
+++ b/src/library/GeoCoding.js
@@ -1,0 +1,53 @@
+const { Util } = require('./Util');
+const axios = require("axios").default;
+
+class GeoCoding {
+
+    /**
+     * 土地名・建物名などから緯度経度情報を取得する
+     * @param {string} keyword 検索キーワード
+     * @returns {Object} 
+     */
+    static async getGeoCode(keyword){
+        try{
+            // 国土交通省-国土地理院のジオコーディングAPIを使用する
+            let url = "https://msearch.gsi.go.jp/address-search/AddressSearch";
+
+            let response = await axios.get(url, {
+                params: {
+                    q: keyword
+                }
+            });
+
+            if(response.status !== 200){
+                Util.error(response);
+                return;
+            }
+
+            // 検索結果なしの場合は終了
+            if(response.data.length <= 0) return;
+
+            // 一件ヒットの場合はそのジオコードを返す
+            else if(response.data.length === 1) return response.data[0];
+            
+            // 複数件ヒットした場合
+            else {
+                let geocode;
+                for(let i=1;i<6;i++){
+                    geocode = response.data
+                                .filter(e=>parseInt(e.properties.dataSource)===i&&e.properties.title.includes(keyword))
+                                .sort((a,b)=>a.properties.title.length - b.properties.title.length)[0];
+                    if(geocode) break;
+                }
+
+                return geocode;
+            }
+
+        }catch(e){
+            Util.error(e);
+            return;
+        }
+    }
+}
+
+module.exports = { GeoCoding };

--- a/src/library/Util.js
+++ b/src/library/Util.js
@@ -75,6 +75,16 @@ class Util{
         return arr[Util.getRandomInt(arr.length)];
     }
 
+    /**
+     * i mod j（剰余）を計算する
+     * @param {*} i 
+     * @param {*} j 
+     * @returns {int}
+     */
+    static mod(i, j) {
+        return (i % j) < 0 ? (i % j) + 0 + (j < 0 ? -j : j) : (i % j + 0);
+    }
+
 
     static emoji = {
         space: '\u200B',

--- a/src/library/Util.js
+++ b/src/library/Util.js
@@ -11,24 +11,22 @@ class Util{
 
     /**
      * 現在日時を返す
-     * @returns ['2023年01月01日00時00分00秒', '2023-1-1_0:0:0']
+     * @returns ['2023年01月01日00時00分00秒', ...]
      */
-    static getTime(){
-        const date1 = new Date();
-        const date2 = date1.getFullYear()                   + "年" +
-            this.padding((date1.getMonth() + 1), '0', 2)    + "月" +
-            this.padding(date1.getDate(), '0', 2)           + "日" +
-            this.padding(date1.getHours(), '0', 2)          + "時" +
-            this.padding(date1.getMinutes(), '0', 2)        + "分" +
-            this.padding(date1.getSeconds(), '0', 2)        + "秒";
-        const date3 = date1.getFullYear() + "-" +
-            this.padding((date1.getMonth() + 1), '0', 2) + "-" +
-            this.padding(date1.getDate(), '0', 2) + "_" +
-            this.padding(date1.getHours(), '0', 2) + ":" +
-            this.padding(date1.getMinutes(), '0', 2) + ":" +
-            this.padding(date1.getSeconds(), '0', 2);
+    static getTime(standard){
+        let date1;
+        if(standard) date1 = new Date(standard);
+        else date1 = new Date();
+        const year = date1.getFullYear();
+        const month = this.padding((date1.getMonth() + 1), '0', 2);
+        const date = this.padding(date1.getDate(), '0', 2);
+        const hours = this.padding(date1.getHours(), '0', 2);
+        const minutes = this.padding(date1.getMinutes(), '0', 2);
+        const seconds = this.padding(date1.getSeconds(), '0', 2);
+        const dayOfWeek = date1.getDay();
+        const date2 = `${year}年${month}月${date}日${hours}時${minutes}分${seconds}秒`;
 
-        return [date2, date3];
+        return [date2, year, month, date, hours, minutes, seconds, dayOfWeek];
     }
 
     /**
@@ -79,9 +77,30 @@ class Util{
 
 
     static emoji = {
+        space: '\u200B',
         raised_hand: '✋',
         arrows_counterclockwise: '🔄',
-        arrow_right: '➡️'
+        arrow_right: '▶️',
+        arrow_left: '◀️',
+        sunny: '☀️',
+        white_sun_small_cloud: '🌤️',
+        partly_sunny: '⛅',
+        white_sun_cloud: '🌥️',
+        white_sun_rain_cloud: '🌦️',
+        cloud: '☁️',
+        cloud_rain: '🌧️',
+        white_sun_rain_cloud: '🌦️',
+        umbrella2: '☂️',
+        closed_umbrella: '🌂',
+        umbrella: '☔',
+        cloud_snow: '🌨️',
+        snowman2: '☃️',
+        cyclone: '🌀',
+        cloud_tornado: '🌪️',
+        fog: '🌫️',
+        zap: '⚡',
+        cloud_lightning: '🌩️',
+        thunder_cloud_rain: '⛈️',
     };
 }
 

--- a/src/library/WeatherForecast.js
+++ b/src/library/WeatherForecast.js
@@ -103,9 +103,4 @@ class WeatherForecast {
 
 }
 
-// WeatherForecast.getWeatherForecastInfo('東京')
-// .then(info=>{
-//     console.log(info);
-// })
-
 module.exports = { WeatherForecast };

--- a/src/library/WeatherForecast.js
+++ b/src/library/WeatherForecast.js
@@ -50,6 +50,11 @@ class WeatherForecast {
                 }
             });
 
+            if(response.status !== 200){
+                Util.error(response);
+                return;
+            }
+
             // 天気を取得した場所名を追加
             response.data.locationName = locationName;
 

--- a/src/library/WeatherForecast.js
+++ b/src/library/WeatherForecast.js
@@ -1,0 +1,106 @@
+const { Util } = require('./Util');
+const { GeoCoding } = require('./GeoCoding');
+const axios = require("axios").default;
+
+class WeatherForecast {
+
+    /**
+     * その土地の天気予報情報を取得する
+     * @param {string} location 場所名・建物名など
+     * @param {string|Date} startDate デフォルトは今日
+     * @param {string|Date} endDate デフォルトは一週間後
+     * @returns {Object}
+     */
+    static async getWeatherForecastInfo(location, startDate, endDate){
+        try{
+            if(!location) return;
+            // 場所名から緯度経度情報を取得
+            let geocode = await GeoCoding.getGeoCode(location);
+            if(!geocode) return;
+            let [longitude, latitude] = geocode.geometry.coordinates;
+            let locationName = geocode.properties.title;
+
+            // 開始/終了日の書式をAPI用に整形。指定されていない場合は、取得範囲は現在時から一週間に設定
+            if(startDate){
+                startDate = Util.getTime(startDate).slice(1,4).join('-');
+            }else{
+                startDate = Util.getTime().slice(1,4).join('-');
+            }
+
+            if(endDate){
+                endDate = Util.getTime(endDate).slice(1,4).join('-');
+            }else{
+                let weeklater = new Date();
+                weeklater.setDate(weeklater.getDate() + 7);
+                endDate = Util.getTime(weeklater).slice(1,4).join('-');
+            }
+
+            // Open-MeteoのAPIを利用して天気を取得する
+            let url = "https://api.open-meteo.com/v1/forecast";
+
+            let response = await axios.get(url, {
+                params: {
+                    latitude,
+                    longitude,
+                    hourly: "temperature_2m,precipitation_probability,precipitation,rain,showers,snowfall,snow_depth,weathercode",
+                    daily: "weathercode,temperature_2m_max,temperature_2m_min,sunrise,sunset,precipitation_sum,snowfall_sum,precipitation_probability_max",
+                    timezone: "Asia/Tokyo",
+                    start_date: startDate,
+                    end_date: endDate
+                }
+            });
+
+            // 天気を取得した場所名を追加
+            response.data.locationName = locationName;
+
+            return response.data;
+
+        }catch(e){
+            Util.error(e);
+            return;
+        }
+    }
+
+    /**
+     * WMO Codeに基づいて気象コードを絵文字に変換する
+     * 参考URL：https://www.jodc.go.jp/data_format/weather-code_j.html
+     * @param {number} weatherCode 
+     * @returns {string} 絵文字
+     */
+    static getWeatherEmoji(weatherCode){
+        weatherCode = parseInt(weatherCode);
+        if(weatherCode<0 || 99<weatherCode) return '';
+        if(weatherCode === 0) return Util.emoji['sunny'];
+        else if(weatherCode === 1)return Util.emoji['white_sun_small_cloud'];
+        else if(weatherCode === 2)return Util.emoji['partly_sunny'];
+        else if(weatherCode === 3)return Util.emoji['cloud'];
+        else if(weatherCode <=  12)return Util.emoji['fog'];
+        else if(weatherCode === 13)return Util.emoji['cloud_lightning'];
+        else if(weatherCode <=  24)return Util.emoji['closed_umbrella'];
+        else if(weatherCode === 25)return Util.emoji['white_sun_rain_cloud'];
+        else if(weatherCode <=  27)return Util.emoji['cloud_snow'];
+        else if(weatherCode === 28)return Util.emoji['fog'];
+        else if(weatherCode === 29)return Util.emoji['thunder_cloud_rain'];
+        else if(weatherCode <=  35)return Util.emoji['fog'];
+        else if(weatherCode <=  40)return Util.emoji['snowman2'];
+        else if(weatherCode <=  49)return Util.emoji['fog'];
+        else if(weatherCode <=  59)return Util.emoji['umbrella2'];
+        else if(weatherCode <=  69)return Util.emoji['umbrella'];
+        else if(weatherCode <=  79)return Util.emoji['snowman2'];
+        else if(weatherCode === 80)return Util.emoji['white_sun_rain_cloud'];
+        else if(weatherCode <=  84)return Util.emoji['umbrella'];
+        else if(weatherCode <=  90)return Util.emoji['snowman2'];
+        else if(weatherCode === 91)return Util.emoji['closed_umbrella'];
+        else if(weatherCode === 92)return Util.emoji['umbrella'];
+        else if(weatherCode <=  94)return Util.emoji['snowman2'];
+        else if(weatherCode <=  99)return Util.emoji['thunder_cloud_rain'];
+    }
+
+}
+
+// WeatherForecast.getWeatherForecastInfo('東京')
+// .then(info=>{
+//     console.log(info);
+// })
+
+module.exports = { WeatherForecast };

--- a/src/library/discord/DiscordWeatherForecast.js
+++ b/src/library/discord/DiscordWeatherForecast.js
@@ -1,23 +1,44 @@
-const { Message, AttachmentBuilder, EmbedBuilder } = require('discord.js');
+const { Message, AttachmentBuilder, EmbedBuilder, Embed } = require('discord.js');
 const { DiscordUtil } = require('../DiscordUtil');
 const { Util } = require('../Util');
-const { commands, getCommand, getBodyText } = require('../command');
 const { WeatherForecast } = require('../WeatherForecast');
 
 
 class DiscordWeatherForecast {
 
+    /**
+     * 天気予報を表示する
+     * @param {Message} msg 
+     * @param {string} location 
+     * @returns 
+     */
     static async showWeatherForecast(msg, location){
         try{
             const left = Util.emoji['arrow_left'];
             const right = Util.emoji['arrow_right'];
+
+            // 今日と一週間後の日付を取得
+            let today = Util.getTime().slice(1,4).join('-');
+            let weeklater = new Date();
+            weeklater.setDate(weeklater.getDate() + 7);
+            weeklater = Util.getTime(weeklater).slice(1,4).join('-');
+
+            // 一週間分の日付文字列を生成
+            let dates = [];
+            let day = new Date();
+            for(let i=0;i<7;i++){                
+                let date = Util.getTime(day);
+                dates.push(`${parseInt(date[2])}/${parseInt(date[3])}(${["日","月","火","水","木","金","土" ][date[7]]})`);
+                day.setDate(day.getDate() + 1);
+            }
+
+            // 表示するembed配列
+            let embeds = [];
+
+            let index = 0;
+
             // 場所が指名されている場合
-            if(location){
-                // 今日と一週間後の日付を取得
-                let today = Util.getTime().slice(1,4).join('-');
-                let weeklater = new Date();
-                weeklater.setDate(weeklater.getDate() + 7);
-                weeklater = Util.getTime(weeklater).slice(1,4).join('-')
+            if(location){                
                 
                 // 一週間分の天気情報を取得
                 const weatherInfo = await WeatherForecast.getWeatherForecastInfo(location, today, weeklater);
@@ -28,66 +49,86 @@ class DiscordWeatherForecast {
                     return;
                 }
 
-                // 週間天気と一週間分の日付文字列を生成してweatherInfoに付加
-                let dates = [];
-                dates.push('週間予報');
-                for(let i=0;i<7;i++){
-                    let date = weatherInfo.hourly.time[i*24].split('T')[0];
-                    date = Util.getTime(date);
-                    dates.push(`${parseInt(date[2])}/${parseInt(date[3])}(${["日","月","火","水","木","金","土" ][date[7]]})`);
-                }
-                weatherInfo.dates = dates;
+                // 一週間分の日付文字列に週間予報の文字列を追加してweatherInfoに付加
+                weatherInfo.dates = ['週間予報'].concat(dates);
+                console.log(weatherInfo.dates);
                 
 
                 // 週間天気と一週間分の1日天気のembedを取得
-                let embeds = [];
                 embeds.push(await DiscordWeatherForecast.getWeekWeatherEmbed(weatherInfo));
                 for(let i=0;i<7;i++){
                     embeds.push(await DiscordWeatherForecast.getOneDayWeatherEmbed(weatherInfo, i));
                 }
-                
-                let index = 0;
-                let rep = await DiscordUtil.replyEmbed(msg, embeds[index]);
-
-                await rep.react(left);
-                await rep.react(right);
-
-                const filter = (reaction, user) => {
-                    return [left,right].includes(reaction.emoji.name) && !user.bot;
-                };
-                const collector = rep.createReactionCollector({ filter, time: 15 * 60 * 1000 });
-
-                collector.on('collect', async (reaction, user) => {
-                    let emoji = reaction.emoji.name;
-                    switch(emoji){
-                        case left:
-                            index = Util.mod(index-1, 8);
-                            DiscordUtil.editEmbed(rep, embeds[index]);                            
-                            break;
-                        case right:
-                            index = Util.mod(index+1, 8);
-                            DiscordUtil.editEmbed(rep, embeds[index]);                            
-                            break;
-                    }
-
-                    // リアクションを削除
-                    reaction.users.remove(user.id);                
-                });
-                
-                collector.on('end', collected => {
-                    rep.reactions.removeAll();
-                });
 
             // 場所が指定されていない場合
             }else{
+                // 全国9箇所の天気を取得
+                let cities = ['札幌', '仙台', '新潟', '東京', '金沢', '名古屋', '大阪', '広島', '高知', '福岡', '那覇']; // 取得する主要地点名
+                let nationalWeatherInfoPromise = []; // 全国の天気情報
+                for(let i=0;i<cities.length;i++){
+                    // 一週間分の天気情報を取得
+                    const weatherInfo = WeatherForecast.getWeatherForecastInfo(cities[i], today, weeklater);
 
+                    // 天気情報を取得出来ていなかった場合は終了
+                    if(!weatherInfo){
+                        DiscordUtil.replyErrorMessage(msg, "場所探せへんかったみたいやわ");
+                        return;
+                    }
+
+                    nationalWeatherInfoPromise.push(weatherInfo);
+                }
+
+                // すべての天気情報が取得出来るのを待つ
+                let nationalWeatherInfo = await Promise.all(nationalWeatherInfoPromise);
+
+                for(let i=0;i<7;i++){
+                    embeds.push(await DiscordWeatherForecast.getNationalOneDayWeatherEmbed(dates, cities, nationalWeatherInfo, i));
+                }
             }
+
+            // リプライしてリアクションを待機
+            let rep = await DiscordUtil.replyEmbed(msg, embeds[index]);
+
+            await rep.react(left);
+            await rep.react(right);
+
+            const filter = (reaction, user) => {
+                return [left,right].includes(reaction.emoji.name) && !user.bot;
+            };
+            const collector = rep.createReactionCollector({ filter, time: 15 * 60 * 1000 });
+
+            collector.on('collect', async (reaction, user) => {
+                let emoji = reaction.emoji.name;
+                switch(emoji){
+                    case left:
+                        index = Util.mod(index-1, embeds.length);
+                        DiscordUtil.editEmbed(rep, embeds[index]);                            
+                        break;
+                    case right:
+                        index = Util.mod(index+1, embeds.length);
+                        DiscordUtil.editEmbed(rep, embeds[index]);                            
+                        break;
+                }
+
+                // リアクションを削除
+                reaction.users.remove(user.id);                
+            });
+            
+            collector.on('end', collected => {
+                rep.reactions.removeAll();
+            });
         }catch(e){
             Util.error(e);
         }
         
     }
 
+    /**
+     * 1日の6時～21時までの天気を表示するエンベッドを生成する
+     * @param {Object} weatherInfo 天気情報
+     * @param {int} index weatherInfo.datesの何番目の日付か
+     * @returns {Embed}
+     */
     static async getOneDayWeatherEmbed(weatherInfo, index){
         try{
             const left = Util.emoji['arrow_left'];
@@ -108,7 +149,7 @@ class DiscordWeatherForecast {
                 const probability = weatherInfo.hourly.precipitation_probability[index*24+hour] + weatherInfo.hourly_units.precipitation_probability;
                 embed.addFields({ name: `${hour}時　`+weatherEmoji+'　　'+empty, value: "```ansi\n" + `\n${red}${temperature}\n${blue}${probability}` + "\n```", inline: true });
             }
-            embed.setFooter({text: `${left}${weatherInfo.dates[(index)%8]}　　　　　　　　　　　　${weatherInfo.dates[(index+2)%8]}${right}`});
+            embed.setFooter({text: `${left}${weatherInfo.dates[Util.mod(index,8)]}　　　　　　　　　　　　${weatherInfo.dates[Util.mod(index+2,8)]}${right}`});
 
             return embed;
 
@@ -118,6 +159,11 @@ class DiscordWeatherForecast {
         }
     }
 
+    /**
+     * 一週間の天気を表示するEmbedを生成する
+     * @param {Object} weatherInfo 天気情報
+     * @returns {Embed}
+     */
     static async getWeekWeatherEmbed(weatherInfo){
         try{
             const left = Util.emoji['arrow_left'];
@@ -150,8 +196,43 @@ class DiscordWeatherForecast {
         }
     }
 
-    static async getNationalOneDayWeatherEmbed(date){
+    /**
+     * その日の全国の天気を表示するEmbedを生成する
+     * @param {Array<string>} dates 一週間の日付文字列
+     * @param {Array<string>} cities 都市名配列
+     * @param {Array<Object>} nationalWeatherInfo 全国の天気情報配列
+     * @param {int} index datesの何番目の日付か
+     * @returns {Embed}
+     */
+    static async getNationalOneDayWeatherEmbed(dates, cities, nationalWeatherInfo, index){
+        try{
+            const left = Util.emoji['arrow_left'];
+            const right = Util.emoji['arrow_right'];
+            const empty = Util.emoji['space'];
+            const red = DiscordUtil.makeStyleKeyword({color:'red'});
+            const blue = DiscordUtil.makeStyleKeyword({color:'blue'});
+            const water = DiscordUtil.makeStyleKeyword({color:'water'});
+            const normal = DiscordUtil.makeStyleKeyword({normal:true});
 
+            let embed = new EmbedBuilder()
+            .setTitle(`${dates[index]} 全国の天気`)
+            .setURL('https://open-meteo.com/');
+
+            for(let i=0;i<cities.length;i++){
+                const weatherEmoji = WeatherForecast.getWeatherEmoji(nationalWeatherInfo[i].daily.weathercode[index]);
+                const temperature_max = nationalWeatherInfo[i].daily.temperature_2m_max[index] + nationalWeatherInfo[index].daily_units.temperature_2m_max;
+                const temperature_min = nationalWeatherInfo[i].daily.temperature_2m_min[index] + nationalWeatherInfo[index].daily_units.temperature_2m_min;
+                const probability = nationalWeatherInfo[i].daily.precipitation_probability_max[index] + nationalWeatherInfo[i].daily_units.precipitation_probability_max;
+                embed.addFields({ name: `${cities[i]}　`+weatherEmoji+'　　'+empty, value: "```ansi\n" + `\n${red}${temperature_max}${normal}/${blue}${temperature_min}\n${water}${probability}` + "\n```", inline: true });
+            }
+            embed.setFooter({text: `${left}${dates[Util.mod(index-1,dates.length)]}　　　　　　　　　　　　　　　　　　　　${dates[Util.mod(index+1,dates.length)]}${right}`});
+
+            return embed;
+
+        }catch(e){
+            Util.error(e);
+            return;
+        }
     }
 
 }

--- a/src/library/discord/DiscordWeatherForecast.js
+++ b/src/library/discord/DiscordWeatherForecast.js
@@ -98,7 +98,8 @@ class DiscordWeatherForecast {
 
             let embed = new EmbedBuilder()
             .setTitle(weatherInfo.locationName)
-            .setDescription(`${weatherInfo.dates[(index+1)%8]}の天気`);
+            .setDescription(`${weatherInfo.dates[(index+1)%8]}の天気`)
+            .setURL('https://open-meteo.com/');
 
             for(let i=0;i<6;i++){
                 const hour = 6+i*3;
@@ -129,7 +130,8 @@ class DiscordWeatherForecast {
 
             let embed = new EmbedBuilder()
             .setTitle(weatherInfo.locationName)
-            .setDescription(`一週間の天気`);
+            .setDescription(`一週間の天気`)
+            .setURL('https://open-meteo.com/');
 
             for(let i=0;i<6;i++){
                 const weatherEmoji = WeatherForecast.getWeatherEmoji(weatherInfo.daily.weathercode[i]);

--- a/src/library/discord/DiscordWeatherForecast.js
+++ b/src/library/discord/DiscordWeatherForecast.js
@@ -1,0 +1,133 @@
+const { Message, AttachmentBuilder, EmbedBuilder } = require('discord.js');
+const { DiscordUtil } = require('../DiscordUtil');
+const { Util } = require('../Util');
+const { commands, getCommand, getBodyText } = require('../command');
+const { WeatherForecast } = require('../WeatherForecast');
+
+
+class DiscordWeatherForecast {
+
+
+
+    static async showWeatherForecast(msg, location){
+        try{
+            const left = Util.emoji['arrow_left'];
+            const right = Util.emoji['arrow_right'];
+            // 場所が指名されている場合
+            if(location){
+                // 今日と一週間後の日付を取得
+                let today = Util.getTime().slice(1,4).join('-');
+                let weeklater = new Date();
+                weeklater.setDate(weeklater.getDate() + 7);
+                weeklater = Util.getTime(weeklater).slice(1,4).join('-')
+                
+                // 今日から一週間分の天気情報を取得
+                const weatherInfo = await WeatherForecast.getWeatherForecastInfo(location, today, weeklater);
+
+                // 週間天気と一週間分の日付文字列を生成してweatherInfoに付加
+                let dates = [];
+                dates.push('週間予報');
+                for(let i=0;i<7;i++){
+                    let date = weatherInfo.hourly.time[i*24].split('T')[0];
+                    date = Util.getTime(date);
+                    dates.push(`${parseInt(date[2])}/${parseInt(date[3])}(${["日","月","火","水","木","金","土" ][date[7]]})`);
+                }
+                weatherInfo.dates = dates;
+                
+
+                // 週間天気と一週間分の1日天気のembedを取得
+                let embeds = [];
+                embeds.push(await DiscordWeatherForecast.getWeekWeatherEmbed(weatherInfo));
+                for(let i=0;i<7;i++){
+                    embeds.push(await DiscordWeatherForecast.getOneDayWeatherEmbed(weatherInfo, i));
+                }
+                
+                let index = 1;
+                console.log("debug: ", embeds[index]);
+                console.log("debug: ", embeds);
+                let rep = await DiscordUtil.replyEmbed(msg, embeds[index]);
+
+                await rep.react(left);
+                await rep.react(right);
+
+                const filter = (reaction, user) => {
+                    return [left,right].includes(reaction.emoji.name) && !user.bot;
+                };
+                const collector = rep.createReactionCollector({ filter, time: 15 * 60 * 1000 });
+
+                collector.on('collect', async (reaction, user) => {
+                    let emoji = reaction.emoji.name;
+                    switch(emoji){
+                        case left:
+                            DiscordUtil.editEmbed(rep, embeds[(index-1)%8]);
+                            index = (index-1)%8;
+                            break;
+                        case right:
+                            DiscordUtil.editEmbed(rep, embeds[(index+1)%8]);
+                            index = (index+1)%8;
+                            break;
+                    }
+
+                    // リアクションを削除
+                    reaction.users.remove(user.id);                
+                });
+                
+                collector.on('end', collected => {
+                    rep.reactions.removeAll();
+                });
+
+            // 場所が指定されていない場合
+            }else{
+
+            }
+        }catch(e){
+            Util.error(e);
+        }
+        
+    }
+
+    static async getOneDayWeatherEmbed(weatherInfo, index){
+        try{
+            console.log('debug index:', index);
+            const left = Util.emoji['arrow_left'];
+            const right = Util.emoji['arrow_right'];
+            const empty = Util.emoji['space'];
+            const red = DiscordUtil.makeStyleKeyword({color:'red'});
+            const blue = DiscordUtil.makeStyleKeyword({color:'blue'});
+
+            // 日付文字列を取得
+            let date = weatherInfo.hourly.time[index*24].split('T')[0].split('-');
+            date = `${date[0]}年${date[1]}月${date[2]}日`;
+
+            let embed = new EmbedBuilder()
+            .setTitle(weatherInfo.locationName)
+            .setDescription(`${weatherInfo.dates[(index+1)%8]}の天気`);
+
+            for(let i=0;i<6;i++){
+                const hour = 6+i*3;
+                const weatherEmoji = WeatherForecast.getWeatherEmoji(weatherInfo.hourly.weathercode[index*24+hour]);
+                const temperature = weatherInfo.hourly.temperature_2m[index*24+hour] + weatherInfo.hourly_units.temperature_2m;
+                const probability = weatherInfo.hourly.precipitation_probability[index*24+hour] + weatherInfo.hourly_units.precipitation_probability;
+                embed.addFields({ name: `${hour}時　`+weatherEmoji+'　　'+empty, value: "```ansi\n" + `\n${red}${temperature}\n${blue}${probability}` + "\n```", inline: true });
+            }
+            embed.setFooter({text: `${left}${weatherInfo.dates[(index)%8]}　　　　　　　　　　　　${weatherInfo.dates[(index+2)%8]}${right}`});
+
+            return embed;
+
+        }catch(e){
+            Util.error(e);
+            return;
+        }
+    }
+
+    static async getWeekWeatherEmbed(weatherInfo){
+        return await DiscordWeatherForecast.getOneDayWeatherEmbed(weatherInfo, 0);
+    }
+
+    static async getNationalOneDayWeatherEmbed(date){
+
+    }
+
+}
+
+module.exports = { DiscordWeatherForecast };


### PR DESCRIPTION
## 概要
さいころ君に天気予報機能を追加した。
```【天気】[場所名]```
でその場所名の天気を検索する。
場所名を指定しない場合は全国の天気を表示する。

## 仕様
場所を指定すると、国土地理院のAPIで緯度・経度情報を取得する。
参考ページ：[国土地理院APIでお手軽ジオコーディング＆逆ジオコーディング](https://memo.appri.me/programming/gsi-geocoding-api)
取得したジオコードをもとに、[open-meteo](https://open-meteo.com/)（フリーの天気予報API）を利用して天気情報を取得する。


## 画像
![image](https://user-images.githubusercontent.com/48784423/228728262-5d6440cb-892e-45ee-a3bf-cc68393acec2.png)
![image](https://user-images.githubusercontent.com/48784423/228728290-928151e9-a1c2-42c6-8c40-f7c89fbe3810.png)
